### PR TITLE
Fix duplicate YAML key causing startup failure

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -69,6 +69,15 @@ virtual-pet:
     low-stat-threshold: 30
     critical-threshold: 15
 
+  # Development CORS (more permissive)
+  cors:
+    allowed-origins:
+      - "http://localhost:5173"
+      - "http://localhost:3000"
+      - "http://127.0.0.1:5173"
+      - "http://127.0.0.1:3000"
+      - "http://localhost:8080"
+
 # Development Actuator (all endpoints exposed)
 management:
   endpoints:
@@ -80,13 +89,3 @@ management:
       show-details: always
     env:
       show-values: always
-
-# Development CORS (more permissive)
-virtual-pet:
-  cors:
-    allowed-origins:
-      - "http://localhost:5173"
-      - "http://localhost:3000"
-      - "http://127.0.0.1:5173"
-      - "http://127.0.0.1:3000"
-      - "http://localhost:8080"


### PR DESCRIPTION
## Summary
- merge duplicate `virtual-pet` entries in `application-dev.yml`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684280ffbce0832d950aa5710fd40a2c